### PR TITLE
ci(chart): fix current ci to publish the helm chart as a tgz archive within the repository

### DIFF
--- a/.github/workflows/ci-chart.yml
+++ b/.github/workflows/ci-chart.yml
@@ -3,7 +3,7 @@ name: ci-chart
 on:
   push:
     tags:
-      - *
+      - '*'
     branches:
       - main
 

--- a/.github/workflows/ci-chart.yml
+++ b/.github/workflows/ci-chart.yml
@@ -2,31 +2,39 @@ name: ci-chart
 
 on:
   push:
+    tags:
+      - *
     branches:
       - main
 
+
 jobs:
-  release:
-    # depending on default permission settings for your org (contents being read-only or read-write for workloads), you will have to add permissions
-    # see: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
+  package:
+    runs-on: ubuntu-latest
     permissions:
       contents: write
-    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Code
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
-      - name: Configure Git
-        run: |
-          git config user.name krateo
-          git config user.email krateo@users.noreply.github.com
-
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        run: |
+          curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
+          sudo apt-get install apt-transport-https --yes
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+          sudo apt-get update
+          sudo apt-get install helm
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+      - name: Package
+        run: |
+          helm package ./chart
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: |
+            *.tgz
         env:
-          CR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/skeleton/.krateoignore
+++ b/skeleton/.krateoignore
@@ -1,5 +1,0 @@
-.github
-skeleton/.github
-
-chart
-skeleton/chart


### PR DESCRIPTION
This PR address the issue with the CI workflow that is not publishing the helm chart as an archive within this repository.